### PR TITLE
ci: update task runners and workflows to handle the monorepo structure dynamically

### DIFF
--- a/.github/packages.py
+++ b/.github/packages.py
@@ -1,3 +1,17 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Output changed packages and which test suites they have.
 
 Assumes that the current working directory is the project root.

--- a/.github/packages.py
+++ b/.github/packages.py
@@ -19,7 +19,7 @@ _GLOBAL_FILES = ('pyproject.toml', 'justfile', '.github')
 
 def _parse_args() -> str:
     parser = argparse.ArgumentParser()
-    parser.add_argument('--git-base-ref')
+    parser.add_argument('git-base-ref')
     args = parser.parse_args()
     return args.git_base_ref
 

--- a/.github/packages.py
+++ b/.github/packages.py
@@ -19,7 +19,7 @@ _GLOBAL_FILES = ('pyproject.toml', 'justfile', '.github')
 
 def _parse_args() -> str:
     parser = argparse.ArgumentParser()
-    parser.add_argument('git-base-ref')
+    parser.add_argument('git_base_ref')
     args = parser.parse_args()
     return args.git_base_ref
 

--- a/.github/packages.py
+++ b/.github/packages.py
@@ -49,7 +49,7 @@ def _main(project_root: pathlib.Path, git_base_ref: str) -> None:
             if (project_root / package / 'tests' / test).is_dir():
                 tests_dict[test].append(package)
     # set output
-    with pathlib.Path(os.environ['GITHUB_OUTPUT']).open('w') as f:
+    with pathlib.Path(os.environ['GITHUB_OUTPUT']).open('a') as f:
         print(f'changed={json.dumps(changed_packages)}', file=f)
         for test, packages in tests_dict.items():
             print(f'{pathlib.PurePath(test).name}={json.dumps(packages)}', file=f)

--- a/.github/packages.py
+++ b/.github/packages.py
@@ -1,0 +1,59 @@
+"""Output changed packages and which test suites they have.
+
+Assumes that the current working directory is the project root.
+The git reference to diff with must be provided as a commandline argument.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import string
+import subprocess
+
+_ALPHABET = tuple(string.ascii_lowercase)
+_GLOBAL_FILES = ('pyproject.toml', 'justfile', '.github')
+
+
+def _parse_args() -> str:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--git-base-ref')
+    args = parser.parse_args()
+    return args.git_base_ref
+
+
+def _main(project_root: pathlib.Path, git_base_ref: str) -> None:
+    git_diff_cmd = ['git', 'diff', '--name-only', f'origin/{git_base_ref}']
+    git_diff = subprocess.run(git_diff_cmd, text=True)
+    changes = git_diff.stdout.split('\n')
+    # record which packages have changed, or all if global config files have changed
+    if any(change.startswith(_GLOBAL_FILES) for change in changes):
+        changed_packages = [
+            path.name
+            for path in project_root.iterdir()
+            if path.is_dir() and path.name.startswith(_ALPHABET)
+        ]
+    else:
+        changed_packages = [
+            change.split('/')[0]
+            for change in changes
+            if (project_root / pathlib.Path(change)).is_dir() and change.startswith(_ALPHABET)
+        ]
+    # record the test suites provided by each package
+    tests = ('unit', 'integration/pebble', 'integration/juju')
+    tests_dict: dict[str, list[str]] = {test: [] for test in tests}
+    for package in changed_packages:
+        for test in tests:
+            if (project_root / package / test).is_dir():
+                tests_dict[test].append(package)
+    # set output
+    with pathlib.Path(os.environ['GITHUB_OUTPUT']).open('w') as f:
+        print(f'changed={json.dumps(changed_packages)}', file=f)
+        for test, packages in tests_dict.items():
+            print(f'{pathlib.PurePath(test).name}={json.dumps(packages)}', file=f)
+
+
+if __name__ == '__main__':
+    _main(project_root=pathlib.Path(), git_base_ref=_parse_args())

--- a/.github/packages.py
+++ b/.github/packages.py
@@ -36,13 +36,11 @@ def _main(project_root: pathlib.Path, git_base_ref: str) -> None:
             if path.is_dir() and path.name.startswith(_ALPHABET)
         )
     else:
-        changed_packages = sorted(
-            {
-                change.split('/')[0]
-                for change in changes
-                if (project_root / change).is_dir() and change.startswith(_ALPHABET)
-            }
-        )
+        changed_packages = sorted({
+            change.split('/')[0]
+            for change in changes
+            if (project_root / change).is_dir() and change.startswith(_ALPHABET)
+        })
     # record the test suites provided by each package
     tests = ('unit', 'integration/pebble', 'integration/juju')
     tests_dict: dict[str, list[str]] = {test: [] for test in tests}

--- a/.github/packages.py
+++ b/.github/packages.py
@@ -26,7 +26,7 @@ def _parse_args() -> str:
 
 def _main(project_root: pathlib.Path, git_base_ref: str) -> None:
     git_diff_cmd = ['git', 'diff', '--name-only', f'origin/{git_base_ref}']
-    git_diff = subprocess.run(git_diff_cmd, text=True)
+    git_diff = subprocess.run(git_diff_cmd, capture_output=True, text=True)
     changes = git_diff.stdout.split('\n')
     # record which packages have changed, or all if global config files have changed
     if any(change.startswith(_GLOBAL_FILES) for change in changes):

--- a/.github/packages.py
+++ b/.github/packages.py
@@ -46,7 +46,7 @@ def _main(project_root: pathlib.Path, git_base_ref: str) -> None:
     tests_dict: dict[str, list[str]] = {test: [] for test in tests}
     for package in changed_packages:
         for test in tests:
-            if (project_root / package / test).is_dir():
+            if (project_root / package / 'tests' / test).is_dir():
                 tests_dict[test].append(package)
     # set output
     with pathlib.Path(os.environ['GITHUB_OUTPUT']).open('w') as f:

--- a/.github/packages.py
+++ b/.github/packages.py
@@ -30,17 +30,19 @@ def _main(project_root: pathlib.Path, git_base_ref: str) -> None:
     changes = git_diff.stdout.split('\n')
     # record which packages have changed, or all if global config files have changed
     if any(change.startswith(_GLOBAL_FILES) for change in changes):
-        changed_packages = [
+        changed_packages = sorted(
             path.name
             for path in project_root.iterdir()
             if path.is_dir() and path.name.startswith(_ALPHABET)
-        ]
+        )
     else:
-        changed_packages = [
-            change.split('/')[0]
-            for change in changes
-            if (project_root / change).is_dir() and change.startswith(_ALPHABET)
-        ]
+        changed_packages = sorted(
+            {
+                change.split('/')[0]
+                for change in changes
+                if (project_root / change).is_dir() and change.startswith(_ALPHABET)
+            }
+        )
     # record the test suites provided by each package
     tests = ('unit', 'integration/pebble', 'integration/juju')
     tests_dict: dict[str, list[str]] = {test: [] for test in tests}

--- a/.github/packages.py
+++ b/.github/packages.py
@@ -39,7 +39,7 @@ def _main(project_root: pathlib.Path, git_base_ref: str) -> None:
         changed_packages = [
             change.split('/')[0]
             for change in changes
-            if (project_root / pathlib.Path(change)).is_dir() and change.startswith(_ALPHABET)
+            if (project_root / change).is_dir() and change.startswith(_ALPHABET)
         ]
     # record the test suites provided by each package
     tests = ('unit', 'integration/pebble', 'integration/juju')

--- a/.github/packages.py
+++ b/.github/packages.py
@@ -43,16 +43,18 @@ def _main(project_root: pathlib.Path, git_base_ref: str) -> None:
         })
     # record the test suites provided by each package
     tests = ('unit', 'integration/pebble', 'integration/juju')
-    tests_dict: dict[str, list[str]] = {test: [] for test in tests}
-    for package in changed_packages:
-        for test in tests:
-            if (project_root / package / 'tests' / test).is_dir():
-                tests_dict[test].append(package)
+    output: dict[str, list[str]] = {test: [] for test in tests}
+    output['changed'] = changed_packages
+    for name in tests:
+        for package in changed_packages:
+            if (project_root / package / 'tests' / name).is_dir():
+                output[name].append(package)
     # set output
     with pathlib.Path(os.environ['GITHUB_OUTPUT']).open('a') as f:
-        print(f'changed={json.dumps(changed_packages)}', file=f)
-        for test, packages in tests_dict.items():
-            print(f'{pathlib.PurePath(test).name}={json.dumps(packages)}', file=f)
+        for name, packages in output.items():
+            line = f'{pathlib.PurePath(name).name}={json.dumps(packages)}'
+            print(line)
+            print(line, file=f)
 
 
 if __name__ == '__main__':

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -115,20 +115,11 @@ jobs:
       - name: Install Pebble
         run: go install github.com/canonical/pebble/cmd/pebble@${{ matrix.pebble-version }}
 
-      - name: Start Pebble
-        run: |
-          umask 0
-          $HOME/go/bin/pebble run --create-dirs &
-        env:
-          PEBBLE: /tmp/pebble-test
-
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
       - name: Run Pebble integration tests
         run: uvx --from rust-just just package=${{ matrix.package }} python=${{ matrix.python-version }} pebble
-        env:
-          PEBBLE: /tmp/pebble-test
 
   juju:
     needs: packages

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -58,7 +58,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Run ${{ matrix.just-recipe }} tests
-        run: uvx --from rust-just just package=${{ matrix.package }} python=${{ matrix.python-version }} static
+        run: uvx --from rust-just just python=${{ matrix.python-version }} static ${{ matrix.package }}
 
   unit:
     needs: packages
@@ -80,7 +80,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Run unit tests
-        run: uvx --from rust-just just package=${{ matrix.package }} python=${{ matrix.python-version }} unit
+        run: uvx --from rust-just just python=${{ matrix.python-version }} unit ${{ matrix.package }}
 
   pebble:
     needs: packages
@@ -119,7 +119,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Run Pebble integration tests
-        run: uvx --from rust-just just package=${{ matrix.package }} python=${{ matrix.python-version }} pebble
+        run: uvx --from rust-just just python=${{ matrix.python-version }} pebble ${{ matrix.package }}
 
   juju:
     needs: packages
@@ -147,4 +147,4 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Run Juju integration tests
-        run: uvx --from rust-just just package=${{ matrix.package }} python=${{ matrix.python-version }} juju
+        run: uvx --from rust-just just python=${{ matrix.python-version }} juju ${{ matrix.package }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
-      - name: Run ${{ matrix.just-recipe }} tests
+      - name: Run static analysis
         run: uvx --from rust-just just python=${{ matrix.python-version }} static ${{ matrix.package }}
 
   unit:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,7 +40,7 @@ jobs:
 
   static:
     needs: packages
-    if: ${{ fromJson(needs.packages.outputs.changed) != '[]' }}
+    if: ${{ toJson(fromJson(needs.packages.outputs.changed)) != '[]' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -62,7 +62,7 @@ jobs:
 
   unit:
     needs: packages
-    if: ${{ fromJson(needs.packages.outputs.unit) != '[]' }}
+    if: ${{ toJson(fromJson(needs.packages.outputs.unit)) != '[]' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -84,7 +84,7 @@ jobs:
 
   pebble:
     needs: packages
-    if: ${{ fromJson(needs.packages.outputs.pebble) != '[]' }}
+    if: ${{ toJson(fromJson(needs.packages.outputs.pebble)) != '[]' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -132,7 +132,7 @@ jobs:
 
   juju:
     needs: packages
-    if: ${{ fromJson(needs.packages.outputs.juju) != '[]' }}
+    if: ${{ toJson(fromJson(needs.packages.outputs.juju)) != '[]' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,64 +20,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
       - name: Collect changed packages and record which test suites they have
         id: packages
-        run: |
-          set -ueo pipefail
-
-          function set_output {
-            NAME=$1
-            set +u  # allow $2 to be missing
-            RAW=$2
-            set -u  # exit on unbound variables again
-            if [[ -z "$RAW" ]]; then
-              OUT="$NAME=[]"
-            else
-              JSON=$(echo $PACKAGES | jq --raw-input --slurp --compact-output 'split("\n")[:-1]')
-              OUT="$NAME=$JSON"
-            fi
-            echo "$OUT"
-            echo "$OUT" >> "$GITHUB_OUTPUT"
-          }
-
-          CHANGES=$(git diff --name-only origin/${{ github.base_ref || 'main' }})
-          GLOBAL=$(echo $CHANGES | grep -e ^pyproject.toml -e ^justfile -e ^.github)
-
-          if [[ -z "$GLOBAL" ]]; then
-            echo 'No changes to repo level config files, running tests for changed packages only.'
-            PACKAGES=$(echo $CHANGES | grep '^[a-z].*/.*' | cut -d'/' -f1 | uniq)
-          else
-            echo 'Changes to repo level config files, running tests for all packages.'
-            PACKAGES=$(ls -1d [a-z]*/ | cut -d'/' -f1)
-          fi
-
-          if [[ -z "$PACKAGES" ]]; then
-            echo 'No packages changed, tests will be skipped.'
-            set_output changed
-            set_output unit
-            set_output pebble
-            set_output juju
-            exit 0
-          fi
-
-          UNIT=()
-          PEBBLE=()
-          JUJU=()
-          for package in $PACKAGES; do
-            if [[ -d "$package/tests/unit" ]]; then
-              UNIT+=("$package")
-            fi
-            if [[ -d "$package/tests/integration/pebble" ]]; then
-              PEBBLE+=("$package")
-            fi
-            if [[ -d "$package/tests/integration/juju" ]]; then
-              JUJU+=("$package")
-            fi
-          done
-          set_output changed "$PACKAGES"
-          set_output unit "${UNIT[@]}"
-          set_output pebble "${PEBBLE[@]}"
-          set_output juju "${JUJU[@]}"
+        run: uv run --no-project --script .github/packages.py ${{ github.base_ref || 'main' }}
 
   lint:
     runs-on: ubuntu-latest

--- a/justfile
+++ b/justfile
@@ -157,6 +157,7 @@ _coverage test_id test_subdir='.' +flags='-rA':
         'tests/{{test_subdir}}/{{test_id}}',
     )
     coverage('xml', '-o', '{{_coverage_dir}}/coverage-{{test_id}}-{{python}}.xml')
+    # let coverage create html directory from scratch
     html_dir = '{{_coverage_dir}}/htmlcov-{{test_id}}-{{python}}'
     if (CWD / html_dir).is_dir():
         shutil.rmtree(CWD / html_dir)

--- a/justfile
+++ b/justfile
@@ -15,7 +15,7 @@ help:
 
 [doc('Run `ruff` and `codespell`, failing if any errors are found.')]
 lint:
-    #!/usr/bin/env -S uv run --python={{python}} --script
+    #!/usr/bin/env -S UV_PROJECT_ENVIRONMENT=.venv-{{python}} uv run --python={{python}} --script
     import subprocess, sys
 
     error_count = 0
@@ -36,12 +36,12 @@ lint:
 
 [doc('Run `ruff check --fix` and `ruff --format`, modifying files in place.')]
 format:
-    uv run --python={{python}} ruff check --preview --fix
-    uv run --python={{python}} ruff format --preview
+    UV_PROJECT_ENVIRONMENT=.venv-{{python}} uv run --python={{python}} ruff check --preview --fix
+    UV_PROJECT_ENVIRONMENT=.venv-{{python}} uv run --python={{python}} ruff format --preview
 
 [doc('Run `pyright` for the specified `package` and `python` version.')]
 static *args:
-    #!/usr/bin/env -S uv run --python={{python}} --group={{package}} --script
+    #!/usr/bin/env -S UV_PROJECT_ENVIRONMENT=.venv-{{package}}-{{python}} uv run --python={{python}} --group={{package}} --script
     import shlex, subprocess, sys
 
     cmd = ['pyright', '--pythonversion={{python}}', *shlex.split('{{args}}')]
@@ -65,7 +65,7 @@ combine-coverage +flags='-rA': (_coverage 'combine' 'all' flags)
 
 [doc("Use uv to install and run coverage for the specified package's tests.")]
 _coverage coverage_cmd test_subdir +flags='-rA':
-    #!/usr/bin/env -S uv run --python={{python}} --group={{package}} --script
+    #!/usr/bin/env -S UV_PROJECT_ENVIRONMENT=.venv-{{package}}-{{python}} uv run --python={{python}} --group={{package}} --script
     import pathlib, shlex, shutil, subprocess, sys
 
     CWD = pathlib.Path('{{justfile_directory()}}/{{package}}')

--- a/justfile
+++ b/justfile
@@ -41,15 +41,9 @@ format:
 
 [doc('Run `pyright` for the specified `package` and `python` version.')]
 static *args:
-    #!/usr/bin/env -S UV_PROJECT_ENVIRONMENT=.venv-{{package}}-{{python}} uv run --python={{python}} --group={{package}} --script
-    import shlex, subprocess, sys
-
-    cmd = ['pyright', '--pythonversion={{python}}', *shlex.split('{{args}}')]
-    print(cmd)
-    try:
-        subprocess.run(cmd, check=True, cwd='{{package}}')
-    except subprocess.CalledProcessError as e:
-        sys.exit(e.returncode)
+    UV_PROJECT_ENVIRONMENT=.venv-{{package}}-{{python}} \
+        uv run --python={{python}} --group={{package}} \
+        pyright --pythonversion={{python}} {{args}}
 
 [doc("Run the specified package's unit tests with the specified python version with `coverage`.")]
 unit +flags='-rA': (_coverage 'run' 'unit' flags)

--- a/justfile
+++ b/justfile
@@ -1,13 +1,5 @@
 set ignore-comments  # don't print comment lines in recipes
 
-# prefix explanations:
-# @ don't print line before execution
-# - continue even if the line fails
-
-# shell options explanation:
-# e.g. set -xueo pipefail
-# x: print lines, exit on u: undefined var, e: cmd failure, o pipefail: even in a pipeline
-
 # set on the commandline as needed, e.g. `just package=pathops python=3.8 unit`
 package := 'pathops'
 python := '3.12'

--- a/justfile
+++ b/justfile
@@ -12,9 +12,6 @@ _pyright_version := '1.1.397'
 _pytest_version := '8.3.5'
 _ruff_version := '0.11.0'
 
-# constants for recipes
-_coverage_dir := '.report'
-
 # this is the first recipe in the file, so it will run if just is called without a recipe
 [doc('Describe usage and list the available recipes.')]
 help:
@@ -114,7 +111,7 @@ _coverage coverage_cmd test_subdir +flags='-rA':
     FLAGS = shlex.split('{{flags}}')
     PYTHON_VERSION = '{{python}}'
     COVERAGE_CMD = '{{coverage_cmd}}'
-    COVERAGE_DIR = '{{_coverage_dir}}'
+    COVERAGE_DIR = '.report'
     TEST_SUBDIR = '{{test_subdir}}'
     TEST_ID = pathlib.PurePath(TEST_SUBDIR).name
     DATA_FILE = f'{COVERAGE_DIR}/coverage-{TEST_ID}-{PYTHON_VERSION}.db'

--- a/justfile
+++ b/justfile
@@ -28,9 +28,9 @@ format:
     uv run --python='{{python}}' ruff format --preview
 
 [doc('Run `pyright` for the specified `package` and `python` version.')]
-static *args:
+static *pyright_args:
     uv run --python='{{python}}' --group='{{package}}' \
-        pyright --pythonversion='{{python}}' {{args}} '{{package}}'
+        pyright --pythonversion='{{python}}' {{pyright_args}} '{{package}}'
 
 [doc("Run the specified package's unit tests with the specified python version with `coverage`.")]
 unit +flags='-rA': (_coverage 'unit' flags)

--- a/justfile
+++ b/justfile
@@ -24,7 +24,7 @@ help:
 lint:
     #!/usr/bin/env -S uv run --python={{python}} --script
     # /// script
-    # dependencies =[
+    # dependencies = [
     #     'ruff=={{_ruff_version}}',
     #     'codespell[toml]=={{_codespell_version}}',
     # ]
@@ -51,7 +51,7 @@ lint:
 format:
     #!/usr/bin/env -S uv run --python={{python}} --script
     # /// script
-    # dependencies =['ruff=={{_ruff_version}}']
+    # dependencies = ['ruff=={{_ruff_version}}']
     # ///
     import subprocess, sys
 
@@ -66,7 +66,7 @@ format:
 static *args:
     #!/usr/bin/env -S uv run --python={{python}} --script
     # /// script
-    # dependencies =[
+    # dependencies = [
     #     'pyright=={{_pyright_version}}',
     #     'pytest=={{_pytest_version}}',
     #     'charmlibs-{{package}} @ {{justfile_directory()}}/{{package}}',
@@ -97,7 +97,7 @@ combine-coverage +flags='-rA': (_coverage 'combine' 'all' flags)
 _coverage coverage_cmd test_subdir +flags='-rA':
     #!/usr/bin/env -S uv run --python={{python}} --script
     # /// script
-    # dependencies = [
+    #  dependencies = [
     #     'pytest=={{_pytest_version}}',
     #     'coverage[toml]=={{_coverage_version}}',
     #     'charmlibs-{{package}} @ {{justfile_directory()}}/{{package}}',

--- a/justfile
+++ b/justfile
@@ -51,9 +51,8 @@ _coverage test_subdir +flags='-rA':
     TEST_SUBDIR = '{{test_subdir}}'
     FLAGS = shlex.split('{{flags}}')
 
-    COVERAGE_DIR = '.report'
     TEST_ID = pathlib.PurePath(TEST_SUBDIR).name
-    DATA_FILE = f'{COVERAGE_DIR}/coverage-{TEST_ID}-{PYTHON_VERSION}.db'
+    DATA_FILE = f'.report/coverage-{TEST_ID}-{PYTHON_VERSION}.db'
 
     def coverage(cmd: str, *args: str) -> None:
         uv = ['uv', 'run', '--active']

--- a/justfile
+++ b/justfile
@@ -45,12 +45,16 @@ juju +flags='-rA': (_coverage 'integration/juju' flags)
 _coverage test_subdir +flags='-rA':
     #!/usr/bin/env bash
     set -xueo pipefail
-    DATA_FILE="{{package}}/.report/coverage-$(basename {{test_subdir}})-{{python}}.db"
-    uv run --python='{{python}}' --group='{{package}}' \
-        coverage run --data-file="$DATA_FILE" --rcfile=pyproject.toml \
-        -m pytest --tb=native -vv '{{flags}}' '{{package}}/tests/{{test_subdir}}'
-    uv run --python='{{python}}' --group='{{package}}' \
-        coverage report --data-file="$DATA_FILE" --rcfile=pyproject.toml
+    uv sync --python='{{python}}' --group='{{package}}'
+    source .venv/bin/activate
+    cd '{{package}}'
+    export COVERAGE_RCFILE=../pyproject.toml
+    DATA_FILE=".report/coverage-$(basename {{test_subdir}})-{{python}}.db"
+    uv run --active \
+        coverage run --data-file="$DATA_FILE" --source='src' \
+        -m pytest --tb=native -vv '{{flags}}' 'tests/{{test_subdir}}'
+    uv run --active \
+        coverage report --data-file="$DATA_FILE"
 
 [doc("Combine `coverage` reports for the specified package and python version.")]
 combine-coverage:

--- a/justfile
+++ b/justfile
@@ -43,7 +43,7 @@ format:
 static *args:
     UV_PROJECT_ENVIRONMENT=.venv-{{package}}-{{python}} \
         uv run --python={{python}} --group={{package}} \
-        pyright --pythonversion={{python}} {{args}}
+        pyright --pythonversion={{python}} {{args}} {{package}}
 
 [doc("Run the specified package's unit tests with the specified python version with `coverage`.")]
 unit +flags='-rA': (_coverage 'run' 'unit' flags)

--- a/justfile
+++ b/justfile
@@ -133,21 +133,22 @@ pebble-local +flags='-rA':
     from subprocess import DEVNULL
 
     ENV = {**os.environ, 'PEBBLE': '/tmp/pebble-test'}
-
-    pebble_cmd = ['pebble', 'run', '--create-dirs']
-    print('Start pebble:', pebble_cmd)
-    pebble_process = subprocess.Popen(pebble_cmd, stdout=DEVNULL, stderr=DEVNULL, env=ENV)
-
-    just_cmd = [
-        'just',
-        '--justfile={{justfile()}}',
-        'package={{package}}',
-        'python={{python}}',
-        'pebble',
-        '{{flags}}',
-    ]
-    print('Run pebble tests:', just_cmd)
-    result = subprocess.run(just_cmd, env=ENV)
-
+    pebble_process = subprocess.Popen(
+        ['pebble', 'run', '--create-dirs'],
+        stdout=DEVNULL,
+        stderr=DEVNULL,
+        env=ENV,
+    )
+    result = subprocess.run(
+        [
+            'just',
+            '--justfile={{justfile()}}',
+            'package={{package}}',
+            'python={{python}}',
+            'pebble',
+            '{{flags}}',
+        ],
+        env=ENV,
+    )
     pebble_process.kill()
     sys.exit(result.returncode)

--- a/justfile
+++ b/justfile
@@ -42,6 +42,7 @@ pebble +flags='-rA':
     #!/usr/bin/env bash
     set -xueo pipefail
     export PEBBLE=/tmp/pebble-test
+    umask 0
     pebble run --create-dirs &>/dev/null &
     PEBBLE_PID=$!
     set +e  # don't exit if the tests fail

--- a/justfile
+++ b/justfile
@@ -128,7 +128,7 @@ combine-coverage:
 
 [doc("Start `pebble`, run pebble integration tests, and shutdown `pebble` cleanly afterwards.")]
 pebble-local +flags='-rA':
-    #!/usr/bin/env -S uv run --python={{python}} --no-project --script
+    #!/usr/bin/env -S uv run --no-project --script
     import os, pathlib, subprocess, sys
     from subprocess import DEVNULL
 

--- a/justfile
+++ b/justfile
@@ -4,8 +4,7 @@ set ignore-comments  # don't print comment lines in recipes
 package := 'pathops'
 python := '3.12'
 
-# dependency versions
-# don't set these on the commandline, they may not be forwarded to other processes
+# dependency versions -- note intended to be set from the commandline
 _codespell_version := '2.3.0'
 _coverage_version := '7.6.1'
 _pyright_version := '1.1.397'

--- a/justfile
+++ b/justfile
@@ -22,12 +22,12 @@ lint:
 
 [doc('Run `ruff check --fix` and `ruff --format`, modifying files in place.')]
 format:
-    uv run --python='{{python}}' ruff check --preview --fix
-    uv run --python='{{python}}' ruff format --preview
+    uv run ruff check --preview --fix
+    uv run ruff format --preview
 
 [doc('Run `pyright`, e.g. `just python=3.8 static pathops`.')]
 static package *pyright_args:
-    uv run --python='{{python}}' --group='{{package}}' \
+    uv run --group='{{package}}' \
         pyright --pythonversion='{{python}}' {{pyright_args}} '{{package}}'
 
 [doc("Run unit tests with `coverage`, e.g. `just python=3.8 unit pathops`.")]

--- a/justfile
+++ b/justfile
@@ -24,13 +24,13 @@ lint:
 
 [doc('Run `ruff check --fix` and `ruff --format`, modifying files in place.')]
 format:
-    uv run --python={{python}} ruff check --preview --fix
-    uv run --python={{python}} ruff format --preview
+    uv run --python='{{python}}' ruff check --preview --fix
+    uv run --python='{{python}}' ruff format --preview
 
 [doc('Run `pyright` for the specified `package` and `python` version.')]
 static *args:
-    uv run --python={{python}} --group={{package}} \
-        pyright --pythonversion={{python}} {{args}} {{package}}
+    uv run --python='{{python}}' --group='{{package}}' \
+        pyright --pythonversion='{{python}}' {{args}} '{{package}}'
 
 [doc("Run the specified package's unit tests with the specified python version with `coverage`.")]
 unit +flags='-rA': (_coverage 'unit' flags)

--- a/justfile
+++ b/justfile
@@ -31,7 +31,7 @@ lint:
         except subprocess.CalledProcessError:
             print(f'Linting command {cmd[0]!r} failed.')
             error_count += 1
-    print(f'Linting done! There were {error_count} error(s).')
+    print(f'Linting done! {error_count} process(es) found errors.')
     sys.exit(error_count)
 
 [doc('Run `ruff check --fix` and `ruff --format`, modifying files in place.')]

--- a/justfile
+++ b/justfile
@@ -127,7 +127,7 @@ _coverage test_subdir +flags='-rA':
             sys.exit(e.returncode)
 
     (CWD / COVERAGE_DIR).mkdir(exist_ok=True)
-    pytest = ['pytest', '--tb=native', '-vv', *FLAGS, f'tests/TEST_SUBDIR']
+    pytest = ['pytest', '--tb=native', '-vv', *FLAGS, f'tests/{TEST_SUBDIR}']
     coverage('run', '--source=src', '-m', *pytest)
     coverage('xml', '-o', XML_FILE)
     # let coverage create html directory from scratch

--- a/justfile
+++ b/justfile
@@ -4,13 +4,6 @@ set ignore-comments  # don't print comment lines in recipes
 package := 'pathops'
 python := '3.12'
 
-# dependency versions -- note intended to be set from the commandline
-_codespell_version := '2.3.0'
-_coverage_version := '7.6.1'
-_pyright_version := '1.1.397'
-_pytest_version := '8.3.5'
-_ruff_version := '0.11.0'
-
 # this is the first recipe in the file, so it will run if just is called without a recipe
 [doc('Describe usage and list the available recipes.')]
 help:
@@ -23,12 +16,6 @@ help:
 [doc('Run `ruff` and `codespell`, failing if any errors are found.')]
 lint:
     #!/usr/bin/env -S uv run --python={{python}} --script
-    # /// script
-    # dependencies = [
-    #     'ruff=={{_ruff_version}}',
-    #     'codespell[toml]=={{_codespell_version}}',
-    # ]
-    # ///
     import subprocess, sys
 
     error_count = 0
@@ -49,29 +36,12 @@ lint:
 
 [doc('Run `ruff check --fix` and `ruff --format`, modifying files in place.')]
 format:
-    #!/usr/bin/env -S uv run --python={{python}} --script
-    # /// script
-    # dependencies = ['ruff=={{_ruff_version}}']
-    # ///
-    import subprocess, sys
-
-    for cmd in (['ruff', 'check', '--preview', '--fix'], ['ruff', 'format', '--preview']):
-        print(cmd)
-        try:
-            subprocess.run(cmd, check=True)
-        except subprocess.CalledProcessError as e:
-            sys.exit(e.returncode)
+    uv run --python={{python}} ruff check --preview --fix
+    uv run --python={{python}} ruff format --preview
 
 [doc('Run `pyright` for the specified `package` and `python` version.')]
 static *args:
-    #!/usr/bin/env -S uv run --python={{python}} --script
-    # /// script
-    # dependencies = [
-    #     'pyright=={{_pyright_version}}',
-    #     'pytest=={{_pytest_version}}',
-    #     'charmlibs-{{package}} @ {{justfile_directory()}}/{{package}}',
-    # ]
-    # ///
+    #!/usr/bin/env -S uv run --python={{python}} --group={{package}} --script
     import shlex, subprocess, sys
 
     cmd = ['pyright', '--pythonversion={{python}}', *shlex.split('{{args}}')]
@@ -95,14 +65,7 @@ combine-coverage +flags='-rA': (_coverage 'combine' 'all' flags)
 
 [doc("Use uv to install and run coverage for the specified package's tests.")]
 _coverage coverage_cmd test_subdir +flags='-rA':
-    #!/usr/bin/env -S uv run --python={{python}} --script
-    # /// script
-    #  dependencies = [
-    #     'pytest=={{_pytest_version}}',
-    #     'coverage[toml]=={{_coverage_version}}',
-    #     'charmlibs-{{package}} @ {{justfile_directory()}}/{{package}}',
-    # ]
-    # ///
+    #!/usr/bin/env -S uv run --python={{python}} --group={{package}} --script
     import pathlib, shlex, shutil, subprocess, sys
 
     CWD = pathlib.Path('{{justfile_directory()}}/{{package}}')

--- a/justfile
+++ b/justfile
@@ -114,9 +114,7 @@ pebble-local +flags='-rA':
 
     pebble_cmd = ['pebble', 'run', '--create-dirs']
     print('Start pebble:', pebble_cmd)
-    pebble_result = subprocess.Popen(pebble_cmd, stdout=DEVNULL, stderr=DEVNULL, env=ENV)
-    pid = pebble_result.pid
-    print(f'Pebble PID: {pid}')
+    pebble_process = subprocess.Popen(pebble_cmd, stdout=DEVNULL, stderr=DEVNULL, env=ENV)
 
     just_cmd = [
         'just',
@@ -129,8 +127,5 @@ pebble-local +flags='-rA':
     print('Run pebble tests:', just_cmd)
     just_result = subprocess.run(just_cmd, env=ENV)
 
-    cleanup_cmd = ['kill', str(pid)]
-    print('Cleanup pebble:', cleanup_cmd)
-    subprocess.run(cleanup_cmd)
-
+    pebble_process.kill()
     sys.exit(just_result.returncode)

--- a/justfile
+++ b/justfile
@@ -158,9 +158,7 @@ pebble-local +flags='-rA':
     import os, pathlib, subprocess, sys
     from subprocess import DEVNULL
 
-    pebble_dir = '/tmp/pebble-test'
-    pathlib.Path(pebble_dir).mkdir(exist_ok=True)
-    ENV = {**os.environ, 'PEBBLE': pebble_dir}
+    ENV = {**os.environ, 'PEBBLE': '/tmp/pebble-test'}
 
     pebble_cmd = ['pebble', 'run', '--create-dirs']
     print('Start pebble:', pebble_cmd)

--- a/justfile
+++ b/justfile
@@ -15,24 +15,12 @@ _help:
 
 [doc('Run `ruff` and `codespell`, failing afterwards if any errors are found.')]
 lint:
-    #!/usr/bin/env -S UV_PROJECT_ENVIRONMENT=.venv-{{python}} uv run --python={{python}} --script
-    import subprocess, sys
-
-    error_count = 0
-    for cmd in (
-        ['ruff', 'check', '--preview', '--diff'],
-        ['ruff', 'format', '--preview', '--diff'],
-        ['codespell', '--toml=pyproject.toml'],
-    ):
-        print(cmd)
-        try:
-            subprocess.run(cmd, check=True)
-            print(f'Linting command {cmd[0]!r} succeeded!')
-        except subprocess.CalledProcessError:
-            print(f'Linting command {cmd[0]!r} failed.')
-            error_count += 1
-    print(f'Linting done! {error_count} process(es) found errors.')
-    sys.exit(error_count)
+    #!/usr/bin/env bash
+    EXITCODE=0
+    uv run ruff check --preview --diff || $EXITCODE=$?
+    uv run ruff format --preview --diff || $EXITCODE=$?
+    codespell --toml=pyproject.toml || $EXITCODE=$?
+    exit $EXITCODE
 
 [doc('Run `ruff check --fix` and `ruff --format`, modifying files in place.')]
 format:

--- a/justfile
+++ b/justfile
@@ -65,7 +65,6 @@ _coverage test_subdir +flags='-rA':
         except subprocess.CalledProcessError as e:
             sys.exit(e.returncode)
 
-    (CWD / COVERAGE_DIR).mkdir(exist_ok=True)
     pytest = ['pytest', '--tb=native', '-vv', *FLAGS, f'tests/{TEST_SUBDIR}']
     coverage('run', '--source=src', '-m', *pytest)
     coverage('report')

--- a/justfile
+++ b/justfile
@@ -125,7 +125,7 @@ pebble-local +flags='-rA':
         '{{flags}}',
     ]
     print('Run pebble tests:', just_cmd)
-    just_result = subprocess.run(just_cmd, env=ENV)
+    result = subprocess.run(just_cmd, env=ENV)
 
     pebble_process.kill()
-    sys.exit(just_result.returncode)
+    sys.exit(result.returncode)

--- a/justfile
+++ b/justfile
@@ -36,13 +36,12 @@ lint:
 
 [doc('Run `ruff check --fix` and `ruff --format`, modifying files in place.')]
 format:
-    UV_PROJECT_ENVIRONMENT=.venv-{{python}} uv run --python={{python}} ruff check --preview --fix
-    UV_PROJECT_ENVIRONMENT=.venv-{{python}} uv run --python={{python}} ruff format --preview
+    uv run --python={{python}} ruff check --preview --fix
+    uv run --python={{python}} ruff format --preview
 
 [doc('Run `pyright` for the specified `package` and `python` version.')]
 static *args:
-    UV_PROJECT_ENVIRONMENT=.venv-{{package}}-{{python}} \
-        uv run --python={{python}} --group={{package}} \
+    uv run --python={{python}} --group={{package}} \
         pyright --pythonversion={{python}} {{args}} {{package}}
 
 [doc("Run the specified package's unit tests with the specified python version with `coverage`.")]

--- a/justfile
+++ b/justfile
@@ -63,11 +63,12 @@ _coverage coverage_cmd test_subdir +flags='-rA':
     import pathlib, shlex, shutil, subprocess, sys
 
     CWD = pathlib.Path('{{package}}')
-    FLAGS = shlex.split('{{flags}}')
     PYTHON_VERSION = '{{python}}'
     COVERAGE_CMD = '{{coverage_cmd}}'
-    COVERAGE_DIR = '.report'
     TEST_SUBDIR = '{{test_subdir}}'
+    FLAGS = shlex.split('{{flags}}')
+
+    COVERAGE_DIR = '.report'
     TEST_ID = pathlib.PurePath(TEST_SUBDIR).name
     DATA_FILE = f'{COVERAGE_DIR}/coverage-{TEST_ID}-{PYTHON_VERSION}.db'
     XML_FILE = f'{COVERAGE_DIR}/coverage-{TEST_ID}-{PYTHON_VERSION}.xml'

--- a/justfile
+++ b/justfile
@@ -39,7 +39,7 @@ lint:
     for cmd in (
         ['ruff', 'check', '--preview', '--diff'],
         ['ruff', 'format', '--preview', '--diff'],
-        ['codespell', '{{justfile_directory()}}', '--toml={{justfile_directory()}}/pyproject.toml'],
+        ['codespell', '--toml=pyproject.toml'],
     ):
         print(cmd)
         try:

--- a/justfile
+++ b/justfile
@@ -25,15 +25,15 @@ format:
     uv run --python='{{python}}' ruff check --preview --fix
     uv run --python='{{python}}' ruff format --preview
 
-[doc('Run `pyright` for the specified `package` and `python` version.')]
+[doc('Run `pyright`, e.g. `just python=3.8 static pathops`.')]
 static package *pyright_args:
     uv run --python='{{python}}' --group='{{package}}' \
         pyright --pythonversion='{{python}}' {{pyright_args}} '{{package}}'
 
-[doc("Run the specified package's unit tests with the specified python version with `coverage`.")]
+[doc("Run unit tests with `coverage`, e.g. `just python=3.8 unit pathops`.")]
 unit package +flags='-rA': (_coverage package 'unit' flags)
 
-[doc("Run the specified package's pebble integration tests with the specified python version with `coverage`.")]
+[doc("Run pebble integration tests with `coverage`. Requires `pebble`.")]
 pebble package +flags='-rA':
     #!/usr/bin/env bash
     set -xueo pipefail
@@ -49,7 +49,7 @@ pebble package +flags='-rA':
     exit $EXITCODE
 
 
-[doc("Run the specified package's juju integration tests with the specified python version with `coverage`.")]
+[doc("Run juju integration tests. Requires `juju`.")]
 juju package +flags='-rA': (_coverage package 'integration/juju' flags)
 
 [doc("Use uv to install and run coverage for the specified package's tests.")]
@@ -65,7 +65,7 @@ _coverage package test_subdir +flags='-rA':
         -m pytest --tb=native -vv '{{flags}}' 'tests/{{test_subdir}}'
     uv run --active coverage report --data-file="$DATA_FILE"
 
-[doc("Combine `coverage` reports for the specified package and python version.")]
+[doc("Combine `coverage` reports, e.g. `just python=3.8 combine-coverage pathops`.")]
 combine-coverage package:
     #!/usr/bin/env bash
     set -xueo pipefail

--- a/justfile
+++ b/justfile
@@ -14,6 +14,7 @@ lint:
     #!/usr/bin/env bash
     set -xueo pipefail
     FAILURES=0
+    uv run ruff check --preview || ((FAILURES+=1))
     uv run ruff check --preview --diff || ((FAILURES+=1))
     uv run ruff format --preview --diff || ((FAILURES+=1))
     uv run codespell --toml=pyproject.toml || ((FAILURES+=1))

--- a/justfile
+++ b/justfile
@@ -68,8 +68,7 @@ _coverage coverage_cmd test_subdir +flags='-rA':
     #!/usr/bin/env -S UV_PROJECT_ENVIRONMENT=.venv-{{package}}-{{python}} uv run --python={{python}} --group={{package}} --script
     import pathlib, shlex, shutil, subprocess, sys
 
-    CWD = pathlib.Path('{{justfile_directory()}}/{{package}}')
-    RCFILE = '{{justfile_directory()}}/pyproject.toml'
+    CWD = pathlib.Path('{{package}}')
     FLAGS = shlex.split('{{flags}}')
     PYTHON_VERSION = '{{python}}'
     COVERAGE_CMD = '{{coverage_cmd}}'
@@ -80,13 +79,13 @@ _coverage coverage_cmd test_subdir +flags='-rA':
     XML_FILE = f'{COVERAGE_DIR}/coverage-{TEST_ID}-{PYTHON_VERSION}.xml'
     HTML_DIR = f'{COVERAGE_DIR}/htmlcov-{TEST_ID}-{PYTHON_VERSION}'
 
-    def coverage(command: str, *args: str) -> None:
+    def coverage(cmd: str, *args: str) -> None:
         uv = ['uv', 'run', '--active']
-        coverage = ['coverage', command, f'--data-file={DATA_FILE}', f'--rcfile={RCFILE}', *args]
-        cmd = [*uv, *coverage]
-        print(cmd)
+        coverage = ['coverage', cmd, f'--data-file={DATA_FILE}', f'--rcfile=pyproject.toml', *args]
+        command = [*uv, *coverage]
+        print(command)
         try:
-            subprocess.run(cmd, check=True, cwd=CWD)
+            subprocess.run(command, check=True, cwd=CWD)
         except subprocess.CalledProcessError as e:
             sys.exit(e.returncode)
 

--- a/justfile
+++ b/justfile
@@ -54,8 +54,6 @@ _coverage test_subdir +flags='-rA':
     COVERAGE_DIR = '.report'
     TEST_ID = pathlib.PurePath(TEST_SUBDIR).name
     DATA_FILE = f'{COVERAGE_DIR}/coverage-{TEST_ID}-{PYTHON_VERSION}.db'
-    XML_FILE = f'{COVERAGE_DIR}/coverage-{TEST_ID}-{PYTHON_VERSION}.xml'
-    HTML_DIR = f'{COVERAGE_DIR}/htmlcov-{TEST_ID}-{PYTHON_VERSION}'
 
     def coverage(cmd: str, *args: str) -> None:
         uv = ['uv', 'run', '--active']
@@ -70,11 +68,6 @@ _coverage test_subdir +flags='-rA':
     (CWD / COVERAGE_DIR).mkdir(exist_ok=True)
     pytest = ['pytest', '--tb=native', '-vv', *FLAGS, f'tests/{TEST_SUBDIR}']
     coverage('run', '--source=src', '-m', *pytest)
-    # let coverage create html directory from scratch
-    if (CWD / HTML_DIR).is_dir():
-        shutil.rmtree(CWD / HTML_DIR)
-    coverage('html', '--show-contexts', f'--directory={HTML_DIR}')
-    coverage('xml', '-o', XML_FILE)
     coverage('report')
 
 [doc("Combine `coverage` reports for the specified package and python version.")]

--- a/justfile
+++ b/justfile
@@ -28,8 +28,7 @@ format:
 
 [doc('Run `pyright`, e.g. `just python=3.8 static pathops`.')]
 static package *pyright_args:
-    uv run --group='{{package}}' \
-        pyright --pythonversion='{{python}}' {{pyright_args}} '{{package}}'
+    uv run --group='{{package}}' pyright --pythonversion='{{python}}' {{pyright_args}} '{{package}}'
 
 [doc("Run unit tests with `coverage`, e.g. `just python=3.8 unit pathops`.")]
 unit package +flags='-rA': (_coverage package 'unit' flags)

--- a/justfile
+++ b/justfile
@@ -6,14 +6,14 @@ python := '3.12'
 
 # this is the first recipe in the file, so it will run if just is called without a recipe
 [doc('Describe usage and list the available recipes.')]
-help:
+_help:
     @echo 'Execute one of the following recipes with {{CYAN}}`just {{BLUE}}$recipe-name{{CYAN}}`{{NORMAL}}.'
     @echo 'All recipes require {{CYAN}}`uv`{{NORMAL}} to be available.'
     @echo 'Set the {{BOLD}}package{{NORMAL}} and {{BOLD}}python{{NORMAL}} version before the recipe name if needed.'
     @echo 'For example, {{CYAN}}`just {{BOLD}}package{{NORMAL}}{{CYAN}}={{package}} {{BOLD}}python{{NORMAL}}{{CYAN}}={{python}} unit`{{NORMAL}}.'
     @just --list --unsorted
 
-[doc('Run `ruff` and `codespell`, failing if any errors are found.')]
+[doc('Run `ruff` and `codespell`, failing afterwards if any errors are found.')]
 lint:
     #!/usr/bin/env -S UV_PROJECT_ENVIRONMENT=.venv-{{python}} uv run --python={{python}} --script
     import subprocess, sys

--- a/justfile
+++ b/justfile
@@ -28,9 +28,9 @@ _pebble_dir := '/tmp/pebble-test'
 [doc('Describe usage and list the available recipes.')]
 help:
     @echo 'Execute one of the following recipes with {{CYAN}}`just {{BLUE}}$recipe-name{{CYAN}}`{{NORMAL}}.'
-    @echo 'Most recipes require {{CYAN}}`uvx`{{NORMAL}} and {{CYAN}}`bash`{{NORMAL}} to be available.'
+    @echo 'All recipes require {{CYAN}}`uv`{{NORMAL}} to be available.'
     @echo 'Set the {{BOLD}}package{{NORMAL}} and {{BOLD}}python{{NORMAL}} version before the recipe name if needed.'
-    @echo 'For example, {{CYAN}}`just {{BOLD}}package{{NORMAL}}{{CYAN}}={{package}} {{BOLD}}python{{NORMAL}}{{CYAN}}={{python}} {{BLUE}}$recipe-name{{CYAN}}`{{NORMAL}}.'
+    @echo 'For example, {{CYAN}}`just {{BOLD}}package{{NORMAL}}{{CYAN}}={{package}} {{BOLD}}python{{NORMAL}}{{CYAN}}={{python}} unit`{{NORMAL}}.'
     @just --list --unsorted
 
 [doc('Run `ruff` and `codespell`, failing if any errors are found.')]

--- a/justfile
+++ b/justfile
@@ -86,16 +86,16 @@ static *args:
         sys.exit(e.returncode)
 
 [doc("Run the specified package's unit tests with the specified python version with `coverage`.")]
-unit +flags='-rA': (_coverage 'unit' '.' flags)
+unit +flags='-rA': (_coverage 'unit' flags)
 
 [doc("Run the specified package's pebble integration tests with the specified python version with `coverage`.")]
-pebble +flags='-rA': (_coverage 'pebble' 'integration' flags)
+pebble +flags='-rA': (_coverage 'pebble' flags)
 
 [doc("Run the specified package's juju integration tests with the specified python version with `coverage`.")]
-juju +flags='-rA': (_coverage 'juju' 'integration' flags)
+juju +flags='-rA': (_coverage 'juju' flags)
 
 [doc("Use uv to install and run coverage for the specified package's tests.")]
-_coverage test_id test_subdir='.' +flags='-rA':
+_coverage test_id +flags='-rA':
     #!/usr/bin/env -S uv run --python={{python}} --script
     # /// script
     # dependencies = [
@@ -122,7 +122,7 @@ _coverage test_id test_subdir='.' +flags='-rA':
 
     (CWD / '{{_coverage_dir}}').mkdir(exist_ok=True)
     flags = shlex.split('{{flags}}')
-    pytest = ['pytest', '--tb=native', '-vv', *flags, 'tests/{{test_subdir}}/{{test_id}}']
+    pytest = ['pytest', '--tb=native', '-vv', *flags, 'tests/**/{{test_id}}']
     coverage('run', '--source=src', '-m', *pytest)
     coverage('xml', '-o', '{{_coverage_dir}}/coverage-{{test_id}}-{{python}}.xml')
     # let coverage create html directory from scratch

--- a/justfile
+++ b/justfile
@@ -43,7 +43,7 @@ juju +flags='-rA': (_coverage 'integration/juju' flags)
 
 [doc("Use uv to install and run coverage for the specified package's tests.")]
 _coverage test_subdir +flags='-rA':
-    #!/usr/bin/env -S UV_PROJECT_ENVIRONMENT=.venv-{{package}}-{{python}} uv run --python={{python}} --group={{package}} --script
+    #!/usr/bin/env -S uv run --python={{python}} --group={{package}} --script
     import pathlib, shlex, shutil, subprocess, sys
 
     CWD = pathlib.Path('{{package}}')

--- a/justfile
+++ b/justfile
@@ -16,11 +16,13 @@ _help:
 [doc('Run `ruff` and `codespell`, failing afterwards if any errors are found.')]
 lint:
     #!/usr/bin/env bash
-    EXITCODE=0
-    uv run ruff check --preview --diff || $EXITCODE=$?
-    uv run ruff format --preview --diff || $EXITCODE=$?
-    codespell --toml=pyproject.toml || $EXITCODE=$?
-    exit $EXITCODE
+    set -xueo pipefail
+    FAILURES=0
+    uv run ruff check --preview --diff || ((FAILURES+=1))
+    uv run ruff format --preview --diff || ((FAILURES+=1))
+    uv run codespell --toml=pyproject.toml || ((FAILURES+=1))
+    : "$FAILURES command(s) failed."
+    exit $FAILURES
 
 [doc('Run `ruff check --fix` and `ruff --format`, modifying files in place.')]
 format:

--- a/justfile
+++ b/justfile
@@ -52,11 +52,9 @@ _coverage test_subdir +flags='-rA':
     cd '{{package}}'
     export COVERAGE_RCFILE=../pyproject.toml
     DATA_FILE=".report/coverage-$(basename {{test_subdir}})-{{python}}.db"
-    uv run --active \
-        coverage run --data-file="$DATA_FILE" --source='src' \
+    uv run --active coverage run --data-file="$DATA_FILE" --source='src' \
         -m pytest --tb=native -vv '{{flags}}' 'tests/{{test_subdir}}'
-    uv run --active \
-        coverage report --data-file="$DATA_FILE"
+    uv run --active coverage report --data-file="$DATA_FILE"
 
 [doc("Combine `coverage` reports for the specified package and python version.")]
 combine-coverage:
@@ -74,18 +72,11 @@ combine-coverage:
     export COVERAGE_RCFILE=pyproject.toml
     DATA_FILE='{{package}}/.report/coverage-all-{{python}}.db'
     HTML_DIR='{{package}}/.report/htmlcov-all-{{python}}'
-    uv run coverage combine --keep \
-        --data-file="$DATA_FILE" \
-        "${data_files[@]}"
-    uv run coverage xml \
-        --data-file="$DATA_FILE" \
-        -o '{{package}}/.report/coverage-all-{{python}}.xml'
+    uv run coverage combine --keep --data-file="$DATA_FILE" "${data_files[@]}"
+    uv run coverage xml --data-file="$DATA_FILE" -o '{{package}}/.report/coverage-all-{{python}}.xml'
     rm -rf "$HTML_DIR"  # let coverage create html directory from scratch
-    uv run coverage html \
-        --data-file="$DATA_FILE" \
-        --show-contexts --directory="$HTML_DIR"
-    uv run coverage report \
-        --data-file="$DATA_FILE"
+    uv run coverage html --data-file="$DATA_FILE" --show-contexts --directory="$HTML_DIR"
+    uv run coverage report --data-file="$DATA_FILE"
 
 [doc("Start `pebble`, run pebble integration tests, and shutdown `pebble` cleanly afterwards.")]
 pebble-local +flags='-rA':

--- a/pathops/tests/integration/pebble/conftest.py
+++ b/pathops/tests/integration/pebble/conftest.py
@@ -26,8 +26,6 @@ if typing.TYPE_CHECKING:
     import pathlib
     from typing import Iterator
 
-os.umask(0o000)  # Pebble seems to operate with umask=0; this makes it easy to compare permissions
-
 
 @pytest.fixture(scope='session')
 def session_dir() -> Iterator[pathlib.Path]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,23 @@
+[project]
+name = "charmtech-charmlibs-monorepo"
+requires-python = '>=3.8'
+version = "0.0.0-dev0"
+
+[dependency-groups]
+dev = [
+    "codespell==2.3.0",
+    "coverage==7.6.1",
+    "pyright==1.1.397",
+    "pytest==8.3.5",
+    "ruff==0.11.0",
+]
+pathops = [
+    'charmlibs-pathops @ file:///${PROJECT_ROOT}/pathops',
+]
+
+[tool.uv]
+package=false
+
 [tool.coverage.run]
 dynamic_context = "test_function"
 branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,7 @@ skip = [
 quiet-level = 3  # disable warnings about (1) wrong encoding + (2) binary files
 
 [tool.pyright]
+ignore = ["_docs"]
 pythonPlatform = "All"
 typeCheckingMode = "strict"
 reportPrivateUsage = false  # things that are effectively public still need to be private to users

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,21 +131,20 @@ ignore = [
 convention = "google"
 
 [tool.codespell]
+check-hidden = true
+quiet-level = 3  # disable warnings about (1) wrong encoding + (2) binary files
 skip = [
     ".git",
-    ".tox",
     ".mypy_cache",
     ".pytest_cache",
+    ".report",
     ".ruff_cache",
+    ".tox",
+    ".venv*",
     ".vscode",
-    "build",
     "_docs",
-    "htmlcov",
-    "htmlcov-*",
-    "venv",
-    "icon.svg",
+    "build",
 ]
-quiet-level = 3  # disable warnings about (1) wrong encoding + (2) binary files
 
 [tool.pyright]
 pythonPlatform = "All"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,11 +12,14 @@ dev = [
     "ruff==0.11.0",
 ]
 pathops = [
-    'charmlibs-pathops @ file:///${PROJECT_ROOT}/pathops',
+    "charmlibs-pathops",
 ]
 
 [tool.uv]
 package=false
+
+[tool.uv.sources]
+charmlibs-pathops = { path = "pathops" }
 
 [tool.coverage.run]
 dynamic_context = "test_function"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,6 @@ skip = [
 quiet-level = 3  # disable warnings about (1) wrong encoding + (2) binary files
 
 [tool.pyright]
-ignore = ["_docs"]
 pythonPlatform = "All"
 typeCheckingMode = "strict"
 reportPrivateUsage = false  # things that are effectively public still need to be private to users


### PR DESCRIPTION
This PR replaces the current `tox.ini`, which is hardcoded to run the tests for the `pathops` package, with a `justfile` that can be parametrized by package name.

The `justfile` provides two public variables, `python` for setting the Python version, and `package` for specifying which package to run tests for. The monorepo's top-level `pyproject.toml` is updated to specify the development dependencies, allowing `uv run` to install these for linting and tests. To install the package itself for testing and static analysis, an optional dependency group is specified for each package, instructing `uv` to install the package from the local files.

The github `tests` workflow is updated to invoke `just` instead of `tox`, passing the appropriate arguments. It also features a new job which checks which packages have changes, and which test suites they have, so that only tests for the changed packages are run in PRs. If global files like the `justfile` or `pyproject.toml` are changed, then tests are run for all packages regardless of other changes.

Where simple commands are not possible in `tests.yaml` and the `justfile`, scripts are used, in-line bash scripts in the `justfile`, and a separate Python script in `.github` for `tests.yaml`.

Static tests for `pathops` are expected to fail with higher Python versions until the following issue is resolved:
- #10